### PR TITLE
Add LoadBalancer Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ forward traffic any cluster.
     * The user must be able to watch Ingresses in all namespaces in all clusters.
       See `k8s-rbac.yml` for more information.
 * Certificates for all your domains.
+* `sysctl net.ipv4.vs.conntrack = 1`
+* Source-NAT rule for the service IP subnet
 
 Each Kubernetes cluster has to expose its API to all the routers. Every kubelet
 node has to be accessible by all routers.

--- a/debian/control
+++ b/debian/control
@@ -14,5 +14,6 @@ Package: k8router
 Architecture: any
 Built-Using: ${misc:Built-Using}
 Depends: ${shlibs:Depends},
-         ${misc:Depends}
+         ${misc:Depends},
+         ipvsadm
 Description: Cluster router for kubernetes

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -1,0 +1,124 @@
+package loadbalancer
+
+import (
+	"fmt"
+	log "github.com/sirupsen/logrus"
+	"github.com/vsk8s/k8router/pkg/state"
+	v1 "k8s.io/api/core/v1"
+	"net"
+	"os/exec"
+	"strings"
+)
+
+// LoadBalancer balances load
+type LoadBalancer struct {
+	loadBalancerChannel chan state.LoadBalancerChange
+
+	ips []*net.IP
+
+	stopChannel chan bool
+}
+
+// Initialize a LoadBalancer
+func Initialize(ips []*net.IP, channel chan state.LoadBalancerChange) *LoadBalancer {
+	return &LoadBalancer{loadBalancerChannel: channel,
+		ips:         ips,
+		stopChannel: make(chan bool)}
+}
+
+// Start a LoadBalancer
+func (h *LoadBalancer) Start() {
+	go h.eventLoop()
+}
+
+// Stop a LoadBalancer
+func (h *LoadBalancer) Stop() {
+	h.stopChannel <- true
+}
+
+func (h *LoadBalancer) eventLoop() {
+	for {
+		select {
+		case event := <-h.loadBalancerChannel:
+			if event.Created {
+				h.createRule(event.Service)
+			} else {
+				h.deleteRule(event.Service)
+			}
+		case _ = <-h.stopChannel:
+			break
+		}
+	}
+}
+
+func (h *LoadBalancer) createRule(service state.LoadBalancer) {
+	log.WithField("service", service.Name).Info("Adding IPVS")
+	for _, ip := range h.ips {
+
+		serviceIP := formatServiceIP(ip, service.Port)
+		protocol := protocolToFlag(service.Protocol)
+		err := exec.Command("ipvsadm",
+			"-A",
+			protocol,
+			serviceIP,
+			"-s",
+			"rr",
+		).Run()
+
+		if err != nil {
+			log.WithError(err).Fatal("Couldn't add service")
+		}
+		err = exec.Command("ipvsadm",
+			"-a",
+			protocol,
+			serviceIP,
+			"-r",
+			fmt.Sprintf("%s:%d", service.IP, service.Port),
+			"-g",
+		).Run()
+		if err != nil {
+			log.WithField("service", service.Name).WithError(err).Error("Couldn't add rule")
+		}
+	}
+}
+
+func formatServiceIP(ip *net.IP, port int32) string {
+	var serviceIP string
+	if strings.Contains(ip.String(), ":") {
+		serviceIP = fmt.Sprintf("[%s]:%d", ip.String(), port)
+	} else {
+		serviceIP = fmt.Sprintf("%s:%d", ip.String(), port)
+	}
+	return serviceIP
+}
+
+func (h *LoadBalancer) deleteRule(service state.LoadBalancer) {
+	log.WithField("service", service.Name).Info("Deleting IPVS")
+	for _, ip := range h.ips {
+
+		serviceIP := formatServiceIP(ip, service.Port)
+		protocol := protocolToFlag(service.Protocol)
+
+		err := exec.Command("ipvsadm",
+			"-D",
+			protocol,
+			serviceIP,
+			"-s",
+			"rr",
+		).Run()
+
+		if err != nil {
+			log.WithField("service", service.Name).WithError(err).Error("Couldn't delete rule")
+		}
+	}
+}
+
+func protocolToFlag(protocol v1.Protocol) string {
+	if protocol == v1.ProtocolTCP {
+		return "-t"
+	} else if protocol == v1.ProtocolUDP {
+		return "-u"
+	} else {
+		return "--sctp-service"
+	}
+}

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -74,7 +74,7 @@ func (h *LoadBalancer) createRule(service state.LoadBalancer) {
 			serviceIP,
 			"-r",
 			fmt.Sprintf("%s:%d", service.IP, service.Port),
-			"-g",
+			"-m",
 		).Run()
 		if err != nil {
 			log.WithField("service", service.Name).WithError(err).Error("Couldn't add rule")

--- a/pkg/router/cluster_test.go
+++ b/pkg/router/cluster_test.go
@@ -22,13 +22,15 @@ func createFakeClientsetAndUUT(t *testing.T, objects ...runtime.Object) (*fake.C
 	})
 	client := fake.NewSimpleClientset(objects...)
 	clusterStateChannel := make(chan state.ClusterState)
+	loadBalancerChannel := make(chan state.LoadBalancerChange)
 	cfg := config.ClusterInternal{
 		Name:             "fake",
 		IngressNamespace: "ingress-nginx",
 	}
 	uut := Initialize(config.Cluster{
 		ClusterInternal: &cfg,
-	}, clusterStateChannel)
+	}, clusterStateChannel,
+		loadBalancerChannel)
 	uut.client = client
 	go func() {
 		go uut.aggregateClusterView()

--- a/pkg/state/clusterState.go
+++ b/pkg/state/clusterState.go
@@ -1,6 +1,9 @@
 package state
 
-import "net"
+import (
+	v1 "k8s.io/api/core/v1"
+	"net"
+)
 
 // K8RouterIngress contains all ingress-related information
 type K8RouterIngress struct {
@@ -12,6 +15,14 @@ type K8RouterIngress struct {
 type K8RouterBackend struct {
 	Name string
 	IP   *net.IP
+}
+
+// LoadBalancer exposes a service externally
+type LoadBalancer struct {
+	Name     string
+	IP       *net.IP
+	Port     int32
+	Protocol v1.Protocol
 }
 
 // ClusterState contains the full state of a given ClusterInternal. This should be enough to build the haproxy config
@@ -30,5 +41,11 @@ type IngressChange struct {
 // BackendChange contains a backend change event
 type BackendChange struct {
 	Backend K8RouterBackend
+	Created bool
+}
+
+// LoadBalancerChange is a change in a loadbalancer event
+type LoadBalancerChange struct {
+	Service LoadBalancer
 	Created bool
 }


### PR DESCRIPTION
Via IPVS

Assumes that ports exposed by LoadBalancers don't collide **across all clusters**. This might be subject to discussion.

IPVS management is done via `exec("ipvsadm")`. I found two libraries for managing IPVS directly in Go, one from [docker](https://github.com/docker/libnetwork/tree/master/ipvs), and [another one](https://github.com/mqliang/libipvs) without commit for one year. What would you prefer?

We somehow have to set SNAT iptables rules, e.g.
`-A POSTROUTING -d <service-ip-subnet> -o <intern_interface> -j MASQUERADE`
Should we set this on startup in k8router or move it to the ansible role? Can one easily do drop-in configuration in iptables?

Closes #5 